### PR TITLE
Add support for JSON format introduced in rsolr 2.0.0

### DIFF
--- a/lib/sunspot/rich_document.rb
+++ b/lib/sunspot/rich_document.rb
@@ -1,8 +1,6 @@
 module Sunspot
 
   class RichDocument < RSolr::Xml::Document
-    include Enumerable
-
     def contains_attachment?
       @fields.each do |field|
         if field.name.to_s.include?("_attachment") && field.value.present?


### PR DESCRIPTION
RSolr introduced a JSON generator in [2.0.0](https://github.com/rsolr/rsolr/blob/master/CHANGES.txt) and made it the default. Attempting to use the `2.3.0` branch together with RSolr >= 2.0.0 with the json encoder results in the following error:

```
NoMethodError (undefined method `each' for #<Sunspot::RichDocument:0x00005625607b0918>):
```

This is due to the fact that [Active Support Core JSON Extension](https://guides.rubyonrails.org/active_support_core_extensions.html#json-support) is used to encode the documents. However, since `RichDocument` includes `Enumerable`, the JSON extension tries to [convert the document into an array](https://github.com/rails/rails/blob/2a3f8a29e5d7d17a0448fa47fd756c8d11b175b1/activesupport/lib/active_support/core_ext/object/json.rb#L132-L136):

```ruby
module Enumerable
  def as_json(options = nil) #:nodoc:
    to_a.as_json(options)
  end
end
```

Removing `include Enumerable` from `RichDocument` resolves this issue.